### PR TITLE
Upgrade to 3.38 runtime

### DIFF
--- a/de.haeckerfelix.Shortwave.json
+++ b/de.haeckerfelix.Shortwave.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "de.haeckerfelix.Shortwave",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
+    "runtime-version" : "3.38",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Pretty easy patch :-)

Maybe useful for others who don't want to install the old 3.36 runtime.
