### PR TITLE
Update gnome runtime to 40

### DIFF
--- a/de.haeckerfelix.Shortwave.json
+++ b/de.haeckerfelix.Shortwave.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "de.haeckerfelix.Shortwave",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.36",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Current runtime, 3.36, is EOL and no longer receiving security updates.