### PR TITLE
Update GNOME runtime to 41

### DIFF
--- a/de.haeckerfelix.Shortwave.json
+++ b/de.haeckerfelix.Shortwave.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "de.haeckerfelix.Shortwave",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Tested this and works. Only problem is that now menu entries have `<sup> </sup>`, it might be better to hold it until a newer release, which might come with newer libadwaita too.