### PR TITLE
git tag is not branch

### DIFF
--- a/de.haeckerfelix.Shortwave.json
+++ b/de.haeckerfelix.Shortwave.json
@@ -45,7 +45,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/libshumate/",
-                    "branch": "1.0.0.alpha.1"
+                    "tag": "1.0.0.alpha.1"
                 }
             ]
         },


### PR DESCRIPTION
This doesn't change the result as it is an actual tag, but using `branch` for git is incorrect when the goal is to be able to reproduce builds.