### PR TITLE
Drop gst-libav

### DIFF
--- a/de.haeckerfelix.Shortwave.json
+++ b/de.haeckerfelix.Shortwave.json
@@ -19,18 +19,6 @@
     },
     "modules" : [
         {
-            "name" : "gst-libav",
-            "buildsystem" : "meson",
-            "cleanup" : ["*.la"],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.20.3.tar.xz",
-                    "sha256": "3fedd10560fcdfaa1b6462cbf79a38c4e7b57d7f390359393fc0cef6dbf27dfe"
-                }
-            ]
-        },
-        {
             "name": "libshumate",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
Drop gst-libav since it's already included in freedesktop platform.